### PR TITLE
add explicit scalatest dependency

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -10,3 +10,4 @@ sparkComponents ++= Seq("sql", "hive")
 
 spDependencies += "MrPowers/spark-fast-tests:0.2.0"
 
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"


### PR DESCRIPTION
Hi Matthew, 
I was playing with with your template a little. Looks like it has compile time issues when trying to run with Spark 2.2.0. Not entirely sure what is the cause (possibly some change in other dependencies), but this one liner seems to solve the issue for 2.2 and works for the default version too.
Since, your template is really easy to get started I thought this one-liner could help "future generations". 
Feel free to accept this PR or turn it in an issue, if you see a better solution. 
Hope it helps and thanks for the cool getting-started code